### PR TITLE
repo_structure update for Directories as Environment

### DIFF
--- a/docs/source/repo_structure.rst
+++ b/docs/source/repo_structure.rst
@@ -34,26 +34,22 @@ Another sample repo structure, showing the same modules nested in environment fo
     ├── dev
     │   ├── myapp.cfn
     │   │   ├── dev-us-west-2.env
-    |   │   ├── prod-us-west-2.env
     │   │   ├── myapp.yaml
     │   │   └── templates
     │   │       └── myapp_cf_template.json
     │   ├── myapp.tf
     │   │   ├── backend.tfvars
     │   │   ├── dev-us-east-1.tfvars
-    |   │   ├── prod-us-east-1.tfvars
     │   │   └── main.tf
     │   └── runway.yml
     └── prod
         ├── myapp.cfn
-        │   ├── dev-us-west-2.env
         │   ├── prod-us-west-2.env
         │   ├── myapp.yaml
         │   └── templates
         │       └── myapp_cf_template.json
         ├── myapp.tf
         │   ├── backend.tfvars
-        │   ├── dev-us-east-1.tfvars
         │   ├── prod-us-east-1.tfvars
         │   └── main.tf
         └── runway.yml
@@ -67,13 +63,11 @@ CloudFormation module at their root (combining the `current_dir` & `ignore_git_b
     .
     ├── dev
     │   ├── dev-us-west-2.env
-    │   ├── prod-us-west-2.env
     │   ├── myapp.yaml
     │   ├── runway.yml
     │   └── templates
     │       └── myapp_cf_template.json
     └── prod
-        ├── dev-us-west-2.env
         ├── prod-us-west-2.env
         ├── myapp.yaml
         ├── runway.yml


### PR DESCRIPTION
Removing the dev env file from the prod folder and the prod env file from the dev folder for 

Directories as Environment
Directories as Environments with a Single Module

It's confusing to see "prod-us-west-2.env" under the dev folder and "dev-us-west-2.env" under the prod folder.